### PR TITLE
Exibido traceback rico para exceções na renderização dos templates

### DIFF
--- a/delorean/templates/title_db_entry.txt
+++ b/delorean/templates/title_db_entry.txt
@@ -91,10 +91,12 @@
 !v151!${title_iso}
 % endif
 ##
-% if other_titles is not UNDEFINED and other_titles:
+% if other_titles is not UNDEFINED and other_titles.has_key('paralleltitle'):
 % for value in other_titles['paralleltitle']:
 !v230!${value}
 % endfor
+% endif
+% if other_titles is not UNDEFINED and other_titles.has_key('other'):
 % for value in other_titles['other']:
 !v240!${value}
 % endfor
@@ -170,10 +172,8 @@
 % endfor
 % endif
 ##
-% if isinstance(publishers, Iterable):
-% for value in publishers:
-!v480!${value}
-% endfor
+% if publisher is not UNDEFINED and publisher:
+!v480!${publisher}
 % endif
 ##
 % if use_license is not UNDEFINED and use_license:

--- a/delorean/tests.py
+++ b/delorean/tests.py
@@ -153,6 +153,12 @@ class DeLoreanTests(unittest.TestCase):
         from delorean.domain import DeLorean
         return DeLorean(*args, **kwargs)
 
+    def test_generate_filename(self):
+        dl = self._makeOne('http://localhost:8000/api/v1/',
+                           datetime_lib=dummy_datetime_factory())
+        self.assertEqual(dl._generate_filename('title'),
+            'title-20120712-10:07:34:803942.tar')
+
     def test_generate_title_bundle(self):
         dl = self._makeOne('http://localhost:8000/api/v1/',
                            datetime_lib=dummy_datetime_factory(),
@@ -162,11 +168,6 @@ class DeLoreanTests(unittest.TestCase):
         self.assertEqual(bundle_url,
             'title-20120712-10:07:34:803942.tar')
 
-    def test_generate_filename(self):
-        dl = self._makeOne('http://localhost:8000/api/v1/',
-                           datetime_lib=dummy_datetime_factory())
-        self.assertEqual(dl._generate_filename('title'),
-            'title-20120712-10:07:34:803942.tar')
 
 class DataCollectorTests(unittest.TestCase):
     title_res = u'http://manager.scielo.org/api/v1/journal/brasil/0102-6720'

--- a/delorean/tests_assets/journal_meta_afterproc.json
+++ b/delorean/tests_assets/journal_meta_afterproc.json
@@ -35,9 +35,7 @@
     "init_year": "1986",
     "other_previous_title": "",
     "init_num": "1",
-    "publishers": [
-        "Colégio Brasileiro de Cirurgia Digestiva"
-    ],
+    "publisher": "Colégio Brasileiro de Cirurgia Digestiva",
     "pub_level": "CT",
     "final_vol": "",
     "cover": null,

--- a/delorean/tests_assets/journal_meta_beforeproc.json
+++ b/delorean/tests_assets/journal_meta_beforeproc.json
@@ -76,9 +76,7 @@
     "pub_level": "CT",
     "pub_status": "current",
     "pub_status_reason": "",
-    "publishers": [
-        "/api/v1/publishers/1/"
-    ],
+    "publisher": "/api/v1/publishers/1/",
     "resource_uri": "/api/v1/journals/1/",
     "scielo_issn": "print",
     "secs_code": "6633",


### PR DESCRIPTION
Estes tracebacks devem ser salvos num arquivo log, e disponibilizados em tempo real numa interface de verificação (/status/traces)
