### PR TITLE
Corrige data de atualização para registros do tipo issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.6
   - 2.7
 install:
+  - pip install -r requirements.txt
   - python setup.py develop
 script:
   - python setup.py test

--- a/delorean/templates/issue_db_entry.txt
+++ b/delorean/templates/issue_db_entry.txt
@@ -59,8 +59,8 @@
 % if ctrl_vocabulary is not UNDEFINED and ctrl_vocabulary:
 !v085!${ctrl_vocabulary}
 % endif
-% if created is not UNDEFINED and created:
-!v091!${created}
+% if updated is not UNDEFINED and updated:
+!v091!${updated}
 % endif
 % if editorial_standard is not UNDEFINED and editorial_standard:
 !v117!${editorial_standard}

--- a/delorean/tests_assets/issue_meta.id
+++ b/delorean/tests_assets/issue_meta.id
@@ -24,7 +24,7 @@
 !v049!^lpt^cABCD-f36r^tTécnica
 !v065!20100300
 !v085!decs
-!v091!20100601
+!v091!20120802
 !v117!vancouv
 !v122!16
 !v130!ABCD. Arquivos Brasileiros de Cirurgia Digestiva (São Paulo)

--- a/delorean/tests_assets/issue_spe_meta.id
+++ b/delorean/tests_assets/issue_spe_meta.id
@@ -24,7 +24,7 @@
 !v049!^lpt^cABCD-f36r^tTécnica
 !v065!20100300
 !v085!decs
-!v091!20100601
+!v091!20120802
 !v117!vancouv
 !v122!16
 !v130!ABCD. Arquivos Brasileiros de Cirurgia Digestiva (São Paulo)


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige a criação de arquivos `id` para as entidades do tipo `issue`. O campo `v91` deve ter seu conteúdo preenchido com a data de **atualização** do registro.

#### Onde a revisão poderia começar?

- `delorean/templates/issue_db_entry.txt`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Configurar o arquivo `development.ini` ou `production.ini` com credenciais de acesso ao SciELO Manager;
- Iniciar a aplicação (`pserve development.ini`);
- Acessar o endereço para gerar o arquivo `id` (http://0.0.0.0:6543/generate/title?collection=saude-publica);
- Descompacte o arquivo `.tar`;
- Abra o arquivo `issue.id`;
- Procure pelo registro de `mfn=2312`;
- Verifique a chave `v91` com valor igual a `20200527`;

#### Algum cenário de contexto que queira dar?

Este BUG ocasiona a não atualização das bases do ArticlesMeta. Em testes realizados, nós temos pelo menos `1900` registros de um total de `2357` que serão atualizados nos próximos processamentos.

### Exemplo

Como exemplo de atualização nós temos a issue de id `0102-311X20200006` com as seguintes atualizações pendentes https://gist.github.com/joffilyfe/95ecea7b004441f227e4e3f0b2396651

#### Quais são tickets relevantes?

scieloorg/isis2mongo/issues/19

### Referências
N/A
